### PR TITLE
Add security configuration with API key filter and update properties …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+.vscode/settings.json

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -44,6 +44,11 @@
 		</dependency>
 
 		<dependency>
+        	<groupId>org.springframework.boot</groupId>
+        	<artifactId>spring-boot-starter-security</artifactId>
+    	</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>

--- a/backend/src/main/java/com/car/analytics/app/config/SecurityConfig.java
+++ b/backend/src/main/java/com/car/analytics/app/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.car.analytics.app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+
+import com.car.analytics.app.filters.ApiKeyFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final ApiKeyFilter apiKeyFilter;
+
+    public SecurityConfig(ApiKeyFilter apiKeyFilter) {
+        this.apiKeyFilter = apiKeyFilter;
+    }
+
+    @Bean
+    public SecurityContextRepository securityContextRepository() {
+        return new RequestAttributeSecurityContextRepository();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .securityContext(context -> context.securityContextRepository(securityContextRepository()))
+            .formLogin(form -> form.disable())
+            .httpBasic(basic -> basic.disable())
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().hasRole("API")
+            )
+            .addFilterBefore(apiKeyFilter, UsernamePasswordAuthenticationFilter.class)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/car/analytics/app/filters/ApiKeyFilter.java
+++ b/backend/src/main/java/com/car/analytics/app/filters/ApiKeyFilter.java
@@ -1,0 +1,65 @@
+package com.car.analytics.app.filters;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Collections;
+
+@Component
+public class ApiKeyFilter extends OncePerRequestFilter {
+
+    @Value("${API.KEY}")
+    private String validApiKey;
+
+    @Value("${ENVIRONMENT:production}")
+    private String environment;
+
+    private static final String API_HEADER = "X-API-KEY";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws java.io.IOException, ServletException {
+        
+        String apiKey = request.getHeader(API_HEADER);
+        String path = request.getRequestURI();
+        
+        System.out.println("=== ApiKeyFilter ===");
+        System.out.println("Path: " + path);
+        System.out.println("API Key received: " + apiKey);
+        System.out.println("Valid API Key: " + validApiKey);
+        System.out.println("Keys match: " + validApiKey.equals(apiKey));
+        
+        if (validApiKey.equals(apiKey)) {
+            UsernamePasswordAuthenticationToken authentication = 
+                new UsernamePasswordAuthenticationToken(
+                    "api-client",  
+                    null,
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_API"))
+                );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            System.out.println("Authentication set: " + SecurityContextHolder.getContext().getAuthentication());
+            filterChain.doFilter(request, response);
+        } else {
+            if ("development".equalsIgnoreCase(environment)) {
+                System.out.println("Invalid API Key: " + apiKey);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Unauthorized: Invalid API Key");
+            } else {
+                // In production, log invalid requests to files or monitoring systems !!!TO-DO!!!
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                response.getWriter().write("Bad Request");
+            }
+        return;
+        }
+    }
+}

--- a/backend/src/main/resources/example.application.properties
+++ b/backend/src/main/resources/example.application.properties
@@ -7,3 +7,9 @@ spring.datasource.password=<Database password>
 
 # This should be set to 'update' only in development environments and none in production
 spring.jpa.hibernate.ddl-auto=update
+
+# Generated API Key for securing endpoints
+API.KEY=your_generated_api_key_here
+# Set the environment to 'development' or 'production' 
+# If not set, defaults to 'production'
+ENVIRONMENT=development 


### PR DESCRIPTION
This pull request introduces API key-based security to the backend by integrating Spring Security and adding a custom filter to authenticate requests using an API key provided in the request header. The changes ensure that only requests with a valid API key can access the backend endpoints, with different responses for invalid keys based on the environment.

**Security integration and configuration:**

* Added the `spring-boot-starter-security` dependency in `pom.xml` to enable Spring Security in the project.
* Created `SecurityConfig.java` to configure stateless security, disable CSRF and form login, and require all requests to have the `ROLE_API` authority, using a custom `ApiKeyFilter` for authentication.

**API key authentication filter:**

* Implemented `ApiKeyFilter.java`, a custom filter that checks for a valid API key in the `X-API-KEY` header, sets the authentication context if valid, and returns appropriate error responses for invalid keys, with behavior differing between development and production environments.

**Configuration and documentation:**

* Updated `example.application.properties` to include properties for `API.KEY` and `ENVIRONMENT`, guiding users to configure the required API key and environment for deployment.…for environment setup

Add .vscode/settings.json to .gitignore to exclude IDE configuration files

Fix return statement placement in ApiKeyFilter to ensure proper flow control

Fix import statement for ApiKeyFilter in SecurityConfig to correct package reference

Moved files which were in wrong folder

Normalize property keys in ApiKeyFilter and example.application.properties to uppercase

Update example.application.properties to clarify environment setting defaults

Enhance security configuration and ApiKeyFilter to include security context repository and improve authentication flow